### PR TITLE
Added `haxelib run pickhaxe setup` Support on MacOS

### DIFF
--- a/src/net/pickhaxe/tools/commands/Build.hx
+++ b/src/net/pickhaxe/tools/commands/Build.hx
@@ -548,6 +548,15 @@ class Build implements ICommand
       }
     }
 
+    // Include the user's dependencies.
+    for (dependency in defines.pickhaxe.mod.dependencies)
+    {
+      if (dependency.endsWith('.jar'))
+      {
+        args = args.concat(['--java-lib', '${dependency}']);
+      }
+    }
+
     // Pass options to the native Java compiler.
     // Any values passed here will be passed to `javac` when generating a JAR.
 

--- a/src/net/pickhaxe/tools/commands/Setup.hx
+++ b/src/net/pickhaxe/tools/commands/Setup.hx
@@ -86,7 +86,7 @@ class Setup implements ICommand
       var source:Path = IO.libraryDir().joinPaths('templates/bin/${Constants.LIBRARY_ID}.sh');
       var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}');
 
-      IO.copyFile(source, target);
+      IO.copyFileUnix(source, target);
     }
     catch (e:Dynamic) {}
   }

--- a/src/net/pickhaxe/tools/commands/Setup.hx
+++ b/src/net/pickhaxe/tools/commands/Setup.hx
@@ -84,7 +84,7 @@ class Setup implements ICommand
     try
     {
       var source:Path = IO.libraryDir().joinPaths('templates/bin/${Constants.LIBRARY_ID}.sh');
-      var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}.sh');
+      var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}');
 
       IO.copyFile(source, target);
     }

--- a/src/net/pickhaxe/tools/commands/Setup.hx
+++ b/src/net/pickhaxe/tools/commands/Setup.hx
@@ -84,7 +84,7 @@ class Setup implements ICommand
     try
     {
       var source:Path = IO.libraryDir().joinPaths('templates/bin/${Constants.LIBRARY_ID}.sh');
-      var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}');
+      var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}.sh');
 
       IO.copyFile(source, target);
     }

--- a/src/net/pickhaxe/tools/commands/Setup.hx
+++ b/src/net/pickhaxe/tools/commands/Setup.hx
@@ -87,6 +87,7 @@ class Setup implements ICommand
       var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}');
 
       IO.copyFileUnix(source, target);
+      IO.updatePermissions(target)
     }
     catch (e:Dynamic) {}
   }

--- a/src/net/pickhaxe/tools/commands/Setup.hx
+++ b/src/net/pickhaxe/tools/commands/Setup.hx
@@ -87,7 +87,7 @@ class Setup implements ICommand
       var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}');
 
       IO.copyFileUnix(source, target);
-      IO.updatePermissions(target)
+      IO.updatePermissions(target);
     }
     catch (e:Dynamic) {}
   }

--- a/src/net/pickhaxe/tools/commands/Setup.hx
+++ b/src/net/pickhaxe/tools/commands/Setup.hx
@@ -78,9 +78,17 @@ class Setup implements ICommand
 
   function setupMac():Void
   {
-    // TODO: Implement this.
-    // https://github.com/openfl/lime/blob/develop/tools/utils/PlatformSetup.hx#L824
-    CLI.print('Sorry, this command is not supported on your platform.');
+    var haxePathEnv:String = Sys.getEnv('HAXEPATH') ?? '/usr/local/bin';
+    var haxePath:Path = new Path(haxePathEnv);
+
+    try
+    {
+      var source:Path = IO.libraryDir().joinPaths('templates/bin/${Constants.LIBRARY_ID}.sh');
+      var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}');
+
+      IO.copyFile(source, target);
+    }
+    catch (e:Dynamic) {}
   }
 
   function setupLinux():Void

--- a/src/net/pickhaxe/tools/schema/PickHaxeDefines.hx
+++ b/src/net/pickhaxe/tools/schema/PickHaxeDefines.hx
@@ -84,6 +84,7 @@ typedef PickHaxeDefinesMod =
   version:String,
   description:String,
   entryPoints:Array<PickHaxeProject.ModEntryPoint>,
+  dependencies:Array<PickHaxeProject.ModDependency>,
   license:String,
 
   authorData:AuthorData,
@@ -373,6 +374,8 @@ class Builder
 
               entryPoints: projectFile.entryPoints,
 
+              dependencies: projectFile?.dependencies ?? [],
+
               // Default license
               license: projectFile?.license?.value ?? 'All Rights Reserved',
 
@@ -537,6 +540,8 @@ class Builder
               parentPackage: projectFile.mod.parentPackage,
 
               entryPoints: projectFile.entryPoints,
+
+              dependencies: projectFile?.dependencies.value ?? {[]},
 
               license: projectFile?.license?.value ?? 'All Rights Reserved',
 

--- a/src/net/pickhaxe/tools/schema/PickHaxeProject.hx
+++ b/src/net/pickhaxe/tools/schema/PickHaxeProject.hx
@@ -31,6 +31,8 @@ typedef PickHaxe =
 
   @:list('mod-contributor') var contributors:Array<ModAuthor>;
 
+  @:list('mod-dependency') var dependencies:Array<ModDependency>;
+
   /**
    * Add new Haxelibs as dependencies to the project.
    */
@@ -164,6 +166,14 @@ typedef ModMetadata =
  * `<mod-license>` tag.
  */
 typedef ModLicense =
+{
+  > ValueTag,
+};
+
+/**
+ * `<mod-dependency>` tag.
+ */
+typedef ModDependency =
 {
   > ValueTag,
 };

--- a/src/net/pickhaxe/tools/util/IO.hx
+++ b/src/net/pickhaxe/tools/util/IO.hx
@@ -279,7 +279,7 @@ class IO
    */
   public static function copyFile(source:Path, dest:Path):Void
   {
-    CFI.print("source: " + source.toString() + ", dest: " + dest.toString()));
+    CFI.print("source: " + source.toString() + ", dest: " + dest.toString());
 
     sys.io.File.copy(source.toString(), dest.toString());
   }

--- a/src/net/pickhaxe/tools/util/IO.hx
+++ b/src/net/pickhaxe/tools/util/IO.hx
@@ -293,6 +293,15 @@ class IO
     Sys.command("sudo", ["cp", source.toString(), dest.toString()]);
   }
 
+  /*
+  * Update permissions for file to not require administration access. (Unix only)
+  * @param path The path to the file to update permissions for.
+  */
+  public static function updatePermissions(path:Path):Void
+  {
+    Sys.command("sudo", ["chmod", "+x", binPath + "/spoopy"]);
+  }
+
   /**
    * Clean up a path and convert it to a Path object.
    * @param input The path to clean up.

--- a/src/net/pickhaxe/tools/util/IO.hx
+++ b/src/net/pickhaxe/tools/util/IO.hx
@@ -279,6 +279,8 @@ class IO
    */
   public static function copyFile(source:Path, dest:Path):Void
   {
+    CFI.print("source: " + source.toString() + ", dest: " + dest.toString()));
+
     sys.io.File.copy(source.toString(), dest.toString());
   }
 

--- a/src/net/pickhaxe/tools/util/IO.hx
+++ b/src/net/pickhaxe/tools/util/IO.hx
@@ -299,7 +299,7 @@ class IO
   */
   public static function updatePermissions(path:Path):Void
   {
-    Sys.command("sudo", ["chmod", "+x", binPath + "/spoopy"]);
+    Sys.command("sudo", ["chmod", "+x", path.toString()]);
   }
 
   /**

--- a/src/net/pickhaxe/tools/util/IO.hx
+++ b/src/net/pickhaxe/tools/util/IO.hx
@@ -279,9 +279,18 @@ class IO
    */
   public static function copyFile(source:Path, dest:Path):Void
   {
-    trace("source: " + source.toString() + ", dest: " + dest.toString());
-
     sys.io.File.copy(source.toString(), dest.toString());
+  }
+
+  /**
+   * Copy a file from one location to another
+   * , requesting administrative access.
+   * @param source The path to the file to copy.
+   * @param dest The path to copy the file to.
+   */
+  public static function copyFileUnix(source:Path, dest:Path):Void
+  {
+    Sys.command("sudo", ["cp", source.toString(), dest.toString()]);
   }
 
   /**

--- a/src/net/pickhaxe/tools/util/IO.hx
+++ b/src/net/pickhaxe/tools/util/IO.hx
@@ -279,7 +279,7 @@ class IO
    */
   public static function copyFile(source:Path, dest:Path):Void
   {
-    CFI.print("source: " + source.toString() + ", dest: " + dest.toString());
+    trace("source: " + source.toString() + ", dest: " + dest.toString());
 
     sys.io.File.copy(source.toString(), dest.toString());
   }

--- a/templates/pickhaxe-project.xsd
+++ b/templates/pickhaxe-project.xsd
@@ -45,6 +45,10 @@
     </xs:complexContent>
   </xs:complexType>
 
+  <xs:complexType name="dependency">
+    <xs:attribute name="value" type="xs:string" use="required" />
+  </xs:complexType>
+
   <xs:element name="pickhaxe">
     <xs:complexType>
       <xs:all>
@@ -52,8 +56,9 @@
         <xs:element name="mod-metadata" type="metadata" minOccurs="1" maxOccurs="1" />
         <xs:element name="mod-license" type="license" minOccurs="0" maxOccurs="1" />
         <xs:element name="mod-contact" type="contact-info" minOccurs="0" maxOccurs="1" />
-        <xs:element name="mod-entry-point" type="entry-point" minOccurs="1" maxOccurs="unbounded"/>
-        <xs:element name="mod-author" type="author" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="mod-entry-point" type="entry-point" minOccurs="1" maxOccurs="unbounded" />
+        <xs:element name="mod-author" type="author" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="mod-dependency" type="dependency" minOccurs="0" maxOccurs="unbounded" />
       </xs:all>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
Due to the Unix OS requiring administrative access to write to the user directory, I relied on the Unix commands to copy the file and turn off administrative permission to execute the executable.

<img width="473" alt="Screen Shot 2023-12-04 at 11 49 00 AM" src="https://github.com/EliteMasterEric/PickHaxe/assets/58647349/ca9cac79-507d-4507-b0f5-037a8873b4ff">
