### PR TITLE
Added `haxelib run pickhaxe setup` Support on MacOS

### DIFF
--- a/src/net/pickhaxe/tools/commands/Setup.hx
+++ b/src/net/pickhaxe/tools/commands/Setup.hx
@@ -86,7 +86,7 @@ class Setup implements ICommand
       var source:Path = IO.libraryDir().joinPaths('templates/bin/${Constants.LIBRARY_ID}.sh');
       var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}');
 
-      IO.copyFile(source, target);
+      IO.copyFileUnix(source, target);
     }
     catch (e:Dynamic) {}
   }

--- a/src/net/pickhaxe/tools/commands/Setup.hx
+++ b/src/net/pickhaxe/tools/commands/Setup.hx
@@ -84,7 +84,7 @@ class Setup implements ICommand
     try
     {
       var source:Path = IO.libraryDir().joinPaths('templates/bin/${Constants.LIBRARY_ID}.sh');
-      var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}.sh');
+      var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}');
 
       IO.copyFile(source, target);
     }

--- a/src/net/pickhaxe/tools/commands/Setup.hx
+++ b/src/net/pickhaxe/tools/commands/Setup.hx
@@ -84,7 +84,7 @@ class Setup implements ICommand
     try
     {
       var source:Path = IO.libraryDir().joinPaths('templates/bin/${Constants.LIBRARY_ID}.sh');
-      var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}');
+      var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}.sh');
 
       IO.copyFile(source, target);
     }

--- a/src/net/pickhaxe/tools/commands/Setup.hx
+++ b/src/net/pickhaxe/tools/commands/Setup.hx
@@ -87,6 +87,7 @@ class Setup implements ICommand
       var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}');
 
       IO.copyFileUnix(source, target);
+      IO.updatePermissions(target)
     }
     catch (e:Dynamic) {}
   }

--- a/src/net/pickhaxe/tools/commands/Setup.hx
+++ b/src/net/pickhaxe/tools/commands/Setup.hx
@@ -87,7 +87,7 @@ class Setup implements ICommand
       var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}');
 
       IO.copyFileUnix(source, target);
-      IO.updatePermissions(target)
+      IO.updatePermissions(target);
     }
     catch (e:Dynamic) {}
   }

--- a/src/net/pickhaxe/tools/commands/Setup.hx
+++ b/src/net/pickhaxe/tools/commands/Setup.hx
@@ -78,9 +78,17 @@ class Setup implements ICommand
 
   function setupMac():Void
   {
-    // TODO: Implement this.
-    // https://github.com/openfl/lime/blob/develop/tools/utils/PlatformSetup.hx#L824
-    CLI.print('Sorry, this command is not supported on your platform.');
+    var haxePathEnv:String = Sys.getEnv('HAXEPATH') ?? '/usr/local/bin';
+    var haxePath:Path = new Path(haxePathEnv);
+
+    try
+    {
+      var source:Path = IO.libraryDir().joinPaths('templates/bin/${Constants.LIBRARY_ID}.sh');
+      var target:Path = haxePath.joinPaths('${Constants.LIBRARY_ID}');
+
+      IO.copyFile(source, target);
+    }
+    catch (e:Dynamic) {}
   }
 
   function setupLinux():Void

--- a/src/net/pickhaxe/tools/util/IO.hx
+++ b/src/net/pickhaxe/tools/util/IO.hx
@@ -279,7 +279,7 @@ class IO
    */
   public static function copyFile(source:Path, dest:Path):Void
   {
-    CFI.print("source: " + source.toString() + ", dest: " + dest.toString()));
+    CFI.print("source: " + source.toString() + ", dest: " + dest.toString());
 
     sys.io.File.copy(source.toString(), dest.toString());
   }

--- a/src/net/pickhaxe/tools/util/IO.hx
+++ b/src/net/pickhaxe/tools/util/IO.hx
@@ -293,6 +293,15 @@ class IO
     Sys.command("sudo", ["cp", source.toString(), dest.toString()]);
   }
 
+  /*
+  * Update permissions for file to not require administration access. (Unix only)
+  * @param path The path to the file to update permissions for.
+  */
+  public static function updatePermissions(path:Path):Void
+  {
+    Sys.command("sudo", ["chmod", "+x", binPath + "/spoopy"]);
+  }
+
   /**
    * Clean up a path and convert it to a Path object.
    * @param input The path to clean up.

--- a/src/net/pickhaxe/tools/util/IO.hx
+++ b/src/net/pickhaxe/tools/util/IO.hx
@@ -279,6 +279,8 @@ class IO
    */
   public static function copyFile(source:Path, dest:Path):Void
   {
+    CFI.print("source: " + source.toString() + ", dest: " + dest.toString()));
+
     sys.io.File.copy(source.toString(), dest.toString());
   }
 

--- a/src/net/pickhaxe/tools/util/IO.hx
+++ b/src/net/pickhaxe/tools/util/IO.hx
@@ -299,7 +299,7 @@ class IO
   */
   public static function updatePermissions(path:Path):Void
   {
-    Sys.command("sudo", ["chmod", "+x", binPath + "/spoopy"]);
+    Sys.command("sudo", ["chmod", "+x", path.toString()]);
   }
 
   /**

--- a/src/net/pickhaxe/tools/util/IO.hx
+++ b/src/net/pickhaxe/tools/util/IO.hx
@@ -279,9 +279,18 @@ class IO
    */
   public static function copyFile(source:Path, dest:Path):Void
   {
-    trace("source: " + source.toString() + ", dest: " + dest.toString());
-
     sys.io.File.copy(source.toString(), dest.toString());
+  }
+
+  /**
+   * Copy a file from one location to another
+   * , requesting administrative access.
+   * @param source The path to the file to copy.
+   * @param dest The path to copy the file to.
+   */
+  public static function copyFileUnix(source:Path, dest:Path):Void
+  {
+    Sys.command("sudo", ["cp", source.toString(), dest.toString()]);
   }
 
   /**

--- a/src/net/pickhaxe/tools/util/IO.hx
+++ b/src/net/pickhaxe/tools/util/IO.hx
@@ -279,7 +279,7 @@ class IO
    */
   public static function copyFile(source:Path, dest:Path):Void
   {
-    CFI.print("source: " + source.toString() + ", dest: " + dest.toString());
+    trace("source: " + source.toString() + ", dest: " + dest.toString());
 
     sys.io.File.copy(source.toString(), dest.toString());
   }


### PR DESCRIPTION
Due to the Unix OS requiring administrative access to write to the user directory, I relied on the Unix commands to copy the file and turn off administrative permission to execute the executable.

<img width="473" alt="Screen Shot 2023-12-04 at 11 49 00 AM" src="https://github.com/EliteMasterEric/PickHaxe/assets/58647349/ca9cac79-507d-4507-b0f5-037a8873b4ff">