### PR TITLE
Added `<mod-dependency />` to project.xml

### DIFF
--- a/src/net/pickhaxe/tools/commands/Build.hx
+++ b/src/net/pickhaxe/tools/commands/Build.hx
@@ -548,6 +548,17 @@ class Build implements ICommand
       }
     }
 
+    // Include the user's dependencies.
+    for (dependency in defines.pickhaxe.mod.dependencies)
+    {
+      var isExtern:String = !dependency.externLib ? '' : '-extern';
+
+      if (dependency.value.endsWith('.jar'))
+      {
+        args = args.concat(['--java-lib' + isExtern, '${dependency.value}']);
+      }
+    }
+
     // Pass options to the native Java compiler.
     // Any values passed here will be passed to `javac` when generating a JAR.
 

--- a/src/net/pickhaxe/tools/schema/PickHaxeDefines.hx
+++ b/src/net/pickhaxe/tools/schema/PickHaxeDefines.hx
@@ -84,6 +84,7 @@ typedef PickHaxeDefinesMod =
   version:String,
   description:String,
   entryPoints:Array<PickHaxeProject.ModEntryPoint>,
+  dependencies:Array<PickHaxeProject.ModDependency>,
   license:String,
 
   authorData:AuthorData,
@@ -373,6 +374,8 @@ class Builder
 
               entryPoints: projectFile.entryPoints,
 
+              dependencies: projectFile?.dependencies ?? [],
+
               // Default license
               license: projectFile?.license?.value ?? 'All Rights Reserved',
 
@@ -537,6 +540,8 @@ class Builder
               parentPackage: projectFile.mod.parentPackage,
 
               entryPoints: projectFile.entryPoints,
+
+              dependencies: projectFile?.dependencies ?? [],
 
               license: projectFile?.license?.value ?? 'All Rights Reserved',
 

--- a/src/net/pickhaxe/tools/schema/PickHaxeProject.hx
+++ b/src/net/pickhaxe/tools/schema/PickHaxeProject.hx
@@ -31,6 +31,8 @@ typedef PickHaxe =
 
   @:list('mod-contributor') var contributors:Array<ModAuthor>;
 
+  @:list('mod-dependency') var dependencies:Array<ModDependency>;
+
   /**
    * Add new Haxelibs as dependencies to the project.
    */
@@ -166,4 +168,17 @@ typedef ModMetadata =
 typedef ModLicense =
 {
   > ValueTag,
+};
+
+/**
+ * `<mod-dependency>` tag.
+ */
+typedef ModDependency =
+{
+  > ValueTag,
+
+  /**
+   * Should the dependency be external.
+   */
+  @:optional @:attr var externLib:Bool;
 };

--- a/templates/pickhaxe-project.xsd
+++ b/templates/pickhaxe-project.xsd
@@ -45,6 +45,11 @@
     </xs:complexContent>
   </xs:complexType>
 
+  <xs:complexType name="dependency">
+    <xs:attribute name="value" type="xs:string" use="required" />
+    <xs:attribute name="externLib" type="xs:boolean" use="optional" />
+  </xs:complexType>
+
   <xs:element name="pickhaxe">
     <xs:complexType>
       <xs:all>
@@ -52,8 +57,9 @@
         <xs:element name="mod-metadata" type="metadata" minOccurs="1" maxOccurs="1" />
         <xs:element name="mod-license" type="license" minOccurs="0" maxOccurs="1" />
         <xs:element name="mod-contact" type="contact-info" minOccurs="0" maxOccurs="1" />
-        <xs:element name="mod-entry-point" type="entry-point" minOccurs="1" maxOccurs="unbounded"/>
-        <xs:element name="mod-author" type="author" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="mod-entry-point" type="entry-point" minOccurs="1" maxOccurs="unbounded" />
+        <xs:element name="mod-author" type="author" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="mod-dependency" type="dependency" minOccurs="0" maxOccurs="unbounded" />
       </xs:all>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
The `<mod-dependency />` tag would allow users to include custom APIs in their Minecraft mod using PickHaxe.

Preview example of how the tag works:

```xml
<!-- The project.xml -->
<mod-dependency value="./dependencies/mcutils.jar" externLib="true" />
<mod-dependency value="./dependencies/seedutils.jar" />
```

```hxml
# The generated build.hxml
--java-lib-extern
./dependencies/mcutils.jar
--java-lib
./dependencies/seedutils.jar
```